### PR TITLE
adds more checks for alt text, removes whitespace, fixes false positive on alt=""

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -94,14 +94,14 @@ documents.onDidChangeContent(change => {
 	validateTextDocument(change.document);
 });
 
-// Only this part is interesting. 
+// Only this part is interesting.
 async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 	let settings = await getDocumentSettings(textDocument.uri);
 	let text = textDocument.getText();
 	let problems = 0;
 	let m: RegExpExecArray | null;
 	let diagnostics: Diagnostic[] = [];
-	
+
 	while ((m = Pattern.pattern.exec(text)) && problems < settings.maxNumberOfProblems) {
 		if (m != null) {
 			let el = m[0].slice(0, 5);
@@ -187,9 +187,9 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
 			message: diagnosticsMessage,
 			source: 'web accessibility'
 		};
-		
+
 		diagnostics.push(diagnosic);
-	}		
+	}
 	connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
 }
 


### PR DESCRIPTION
### Fixed the following Issues:
https://github.com/mvdschee/web-accessibility/issues/6

### Added the following Features:
- No longer flags alt="" as false, since this is a best practice for purely decorative images, and alters error message accordingly
- Checks for bad alts like "image" and "picture"
- Checks for bad alt beginnings, like "image of" and "picture of"
- Adds a length check for alts, since most screen readers cut off after 125 characters
- Removes some extraneous whitespace found in the course of working on this issue