### PR TITLE
Adapt some patterns

### DIFF
--- a/server/src/accessibilityPatterns.ts
+++ b/server/src/accessibilityPatterns.ts
@@ -165,7 +165,7 @@ export async function validateTitle(m: RegExpExecArray) {
 		};
 	} else {
 		titleRegEx = /<title>(?:.*[a-z].*|\s*)?<\/title>/i.exec(oldRegEx[0]);
-		if (/>(?:|\s+?)</i.test(titleRegEx[0])) {
+		if (/<title>\s*<\/title>/i.test(titleRegEx[0])) {
 			titleRegEx.index = oldRegEx.index + titleRegEx.index;
 			return {
 				meta: titleRegEx,

--- a/server/src/accessibilityPatterns.ts
+++ b/server/src/accessibilityPatterns.ts
@@ -14,15 +14,15 @@ const patterns: string[] = [
 	'<div(?:\\s+[^>]*)?>',
 	'<span(?:\\s+[^>]*)?>',
 	// "id=\"(?:.)+?\"",
-	'<a(?:\\s+[^>]*)?>([\\s\\S]*)(?=</a>)',
+	'<a(?:\\s+[^>]*)?>(.*)(?=</a>)',
 	'<img(?:\\s+[^>]*)?>',
 	'<input(?:\\s+[^>]*)?>',
-	'<head(?:\\s+[^>]*)?>([\\s\\S]*)(?=</head>)',
+	'<head(?:\\s+[^>]*)?>(.*)(?=</head>)',
 	'<html(?:\\s+[^>]*)?>',
 	'tabindex=".*"',
 	'<i?frame(?:\\s+[^>]*)?>',
 ];
-export const pattern: RegExp = new RegExp(patterns.join('|'), 'igm');
+export const pattern: RegExp = new RegExp(patterns.join('|'), 'igs');
 
 const nonDescriptiveAlts: string[] = [
 	'alt="image"',
@@ -63,9 +63,9 @@ export async function validateDiv(m: RegExpExecArray) {
 }
 
 export async function validateSpan(m: RegExpExecArray) {
-	if (!/role=(?:.*[a-z].*)"/i.test(m[0])) {
-		if (!/<span(?:.*)(?:aria-hidden="true)(?:.*)>/.test(m[0])) {
-			if (/<span(?:.*)(?:button|btn)(?:.*)>/.test(m[0])) {
+	if (!/role=(?:.*[a-z].*)"/im.test(m[0])) {
+		if (!/<span(?:.*)(?:aria-hidden="true)(?:.*)>/si.test(m[0])) {
+			if (/<span(?:.*)(?:button|btn)(?:.*)>/si.test(m[0])) {
 				return {
 					meta: m,
 					mess: 'Change the span to a <button>',

--- a/server/src/accessibilityPatterns.ts
+++ b/server/src/accessibilityPatterns.ts
@@ -11,16 +11,16 @@
 
 // Order based om most common types first
 const patterns: string[] = [
-	'<div(?:\\s*|\\s+[^>]+)>',
-	'<span(?:\\s*|\\s+[^>]+)>',
+	'<div(?:\\s+[^>]*)?>',
+	'<span(?:\\s+[^>]*)?>',
 	// "id=\"(?:.)+?\"",
-	'<a(?:\\s*|\\s+.+)>([\\s\\S]*)(?=</a>)',
-	'<img(?:\\s*/?|\\s+[^>]+)>',
-	'<input(?:\\s*/?|\\s+[^>]+)>',
-	'<head(?:\\s*|\\s+.+)>([\\s\\S]*)(?=</head>)',
-	'<html(?:\\s*/?|\\s+[^>]+)>',
+	'<a(?:\\s+[^>]*)?>([\\s\\S]*)(?=</a>)',
+	'<img(?:\\s+[^>]*)?>',
+	'<input(?:\\s+[^>]*)?>',
+	'<head(?:\\s+[^>]*)?>([\\s\\S]*)(?=</head>)',
+	'<html(?:\\s+[^>]*)?>',
 	'tabindex=".*"',
-	'<i?frame(?:\\s*|\\s+[^>]+)>',
+	'<i?frame(?:\\s+[^>]*)?>',
 ];
 export const pattern: RegExp = new RegExp(patterns.join('|'), 'igm');
 

--- a/server/src/accessibilityPatterns.ts
+++ b/server/src/accessibilityPatterns.ts
@@ -11,16 +11,16 @@
 
 // Order based om most common types first
 const patterns: string[] = [
-	'<div(?:\\s*|\\s+.+)>',
-	'<span(?:\\s*|\\s+.+)>',
+	'<div(?:\\s*|\\s+[^>]+)>',
+	'<span(?:\\s*|\\s+[^>]+)>',
 	// "id=\"(?:.)+?\"",
-	'<a (?:.)+?>(?:(?:\\s|\\S)+?(?=</a>))</a>',
-	'<img(?:\\s*/?|\\s+.+)>',
-	'<input(?:\\s*/?|\\s+.+)>',
-	'<head(?:\\s*|\\s+.+)>(?:(?:\\s|\\S|)+?(?=</head>))</head>',
-	'<html(?:\\s*/?|\\s+.+)>',
+	'<a(?:\\s*|\\s+.+)>([\\s\\S]*)(?=</a>)',
+	'<img(?:\\s*/?|\\s+[^>]+)>',
+	'<input(?:\\s*/?|\\s+[^>]+)>',
+	'<head(?:\\s*|\\s+.+)>([\\s\\S]*)(?=</head>)',
+	'<html(?:\\s*/?|\\s+[^>]+)>',
 	'tabindex=".*"',
-	'<i?frame(?:\\s*|\\s+.+)>',
+	'<i?frame(?:\\s*|\\s+[^>]+)>',
 ];
 export const pattern: RegExp = new RegExp(patterns.join('|'), 'igm');
 
@@ -63,9 +63,9 @@ export async function validateDiv(m: RegExpExecArray) {
 }
 
 export async function validateSpan(m: RegExpExecArray) {
-	if (!/role=(?:.*?[a-z].*?)"/i.test(m[0])) {
-		if (!/<span(?:.+?)(?:aria-hidden="true)(?:.+?)>/.test(m[0])) {
-			if (/<span(?:.+?)(?:button|btn)(?:.+?)>/.test(m[0])) {
+	if (!/role=(?:.*[a-z].*)"/i.test(m[0])) {
+		if (!/<span(?:.*)(?:aria-hidden="true)(?:.*)>/.test(m[0])) {
+			if (/<span(?:.*)(?:button|btn)(?:.*)>/.test(m[0])) {
 				return {
 					meta: m,
 					mess: 'Change the span to a <button>',
@@ -85,9 +85,9 @@ export async function validateSpan(m: RegExpExecArray) {
 export async function validateA(m: RegExpExecArray) {
 	let aRegEx: RegExpExecArray;
 	let oldRegEx: RegExpExecArray = m;
-	let filteredString = m[0].replace(/<(?:\s|\S)+?>/gi, '');
-	if (!/(?:\S+?)/gi.test(filteredString)) {
-		aRegEx = /<a(?:.)+?>/i.exec(oldRegEx[0]);
+	let filteredString = m[0].replace(/<(?:[\s\S]*)>/gi, '');
+	if (!/(?:\S*)/gi.test(filteredString)) {
+		aRegEx = /<a(?:.*)>/i.exec(oldRegEx[0]);
 		aRegEx.index = oldRegEx.index;
 		return {
 			meta: aRegEx,
@@ -99,7 +99,7 @@ export async function validateA(m: RegExpExecArray) {
 
 export async function validateImg(m: RegExpExecArray) {
 	// Ordered by approximate frequency of the issue
-	if (!/alt="(?:.*?[a-z].*?)"/i.test(m[0]) && !/alt=""/i.test(m[0])) {
+	if (!/alt="(?:.*[a-z].*)"/i.test(m[0]) && !/alt=""/i.test(m[0])) {
 		return {
 			meta: m,
 			mess: 'Provide an alt text that describes the image, or alt="" if image is purely decorative',
@@ -121,7 +121,7 @@ export async function validateImg(m: RegExpExecArray) {
 		};
 	}
 	// Most screen readers cut off alt text at 125 characters.
-	if (/alt="(?:.*?[a-z].*.{125,}?)"/i.test(m[0])) {
+	if (/alt="(?:.*[a-z].{125,}?)"/i.test(m[0])) {
 		return {
 			meta: m,
 			mess: 'Alt text is too long',
@@ -133,7 +133,7 @@ export async function validateImg(m: RegExpExecArray) {
 export async function validateMeta(m: RegExpExecArray) {
 	let metaRegEx: RegExpExecArray;
 	let oldRegEx: RegExpExecArray = m;
-	if ((metaRegEx = /<meta(?:.+?)viewport(?:.+?)>/i.exec(oldRegEx[0]))) {
+	if ((metaRegEx = /<meta(?:.*)viewport(?:.*)>/i.exec(oldRegEx[0]))) {
 		metaRegEx.index = oldRegEx.index + metaRegEx.index;
 		if (!/user-scalable=yes/i.test(metaRegEx[0])) {
 			return {
@@ -156,7 +156,7 @@ export async function validateTitle(m: RegExpExecArray) {
 	let titleRegEx: RegExpExecArray;
 	let oldRegEx: RegExpExecArray = m;
 	if (!/<title>/i.test(oldRegEx[0])) {
-		titleRegEx = /<head(?:|.+?)>/i.exec(oldRegEx[0]);
+		titleRegEx = /<head(?:.*)>/i.exec(oldRegEx[0]);
 		titleRegEx.index = oldRegEx.index;
 		return {
 			meta: titleRegEx,
@@ -164,7 +164,7 @@ export async function validateTitle(m: RegExpExecArray) {
 			severity: 1,
 		};
 	} else {
-		titleRegEx = /<title>(?:|.*?[a-z].*?|\s+?)<\/title>/i.exec(oldRegEx[0]);
+		titleRegEx = /<title>(?:.*[a-z].*|\s*)?<\/title>/i.exec(oldRegEx[0]);
 		if (/>(?:|\s+?)</i.test(titleRegEx[0])) {
 			titleRegEx.index = oldRegEx.index + titleRegEx.index;
 			return {
@@ -177,7 +177,7 @@ export async function validateTitle(m: RegExpExecArray) {
 }
 
 export async function validateHtml(m: RegExpExecArray) {
-	if (!/lang=(?:.*?[a-z].*?)"/i.test(m[0])) {
+	if (!/lang=(?:.*[a-z].*)"/i.test(m[0])) {
 		return {
 			meta: m,
 			mess: 'Provide a language [lang=""]',
@@ -191,7 +191,7 @@ export async function validateInput(m: RegExpExecArray) {
 		case /type="hidden"/i.test(m[0]):
 			break;
 		case /aria-label=/i.test(m[0]):
-			if (!/aria-label="(?:(?![a-z]*?)|\s|)"/i.test(m[0])) {
+			if (!/aria-label="(?:(?![a-z]*)|\s*)"/i.test(m[0])) {
 				break;
 			} else {
 				return {
@@ -201,8 +201,8 @@ export async function validateInput(m: RegExpExecArray) {
 				};
 			}
 		case /id=/i.test(m[0]):
-			if (/id="(?:.*?[a-z].*?)"/i.test(m[0])) {
-				let idValue = /id="(.*?[a-z].*?)"/i.exec(m[0])[1];
+			if (/id="(?:.*[a-z].*)"/i.test(m[0])) {
+				let idValue = /id="(.*[a-z].*)"/i.exec(m[0])[1];
 				let pattern: RegExp = new RegExp('for="' + idValue + '"', 'i');
 				if (pattern.test(m.input)) {
 					break;
@@ -221,7 +221,7 @@ export async function validateInput(m: RegExpExecArray) {
 				};
 			}
 		case /aria-labelledby=/i.test(m[0]):
-			if (!/aria-labelledby="(?:(?![a-z]*?)|\s|)"/i.test(m[0])) {
+			if (!/aria-labelledby="(?:(?![a-z]*?)|\s?)"/i.test(m[0])) {
 				// TODO: needs to check elements with the same value.
 				break;
 			} else {
@@ -254,7 +254,7 @@ export async function validateTab(m: RegExpExecArray) {
 }
 
 export async function validateFrame(m: RegExpExecArray) {
-	if (!/title=(?:.*?[a-z].*?)"/i.test(m[0])) {
+	if (!/title=(?:.*[a-z].*)"/i.test(m[0])) {
 		return {
 			meta: m,
 			mess: 'Provide a title that describes the frame\'s content [title=""]',

--- a/server/src/accessibilityPatterns.ts
+++ b/server/src/accessibilityPatterns.ts
@@ -11,18 +11,18 @@
 
 // Order based om most common types first
 const patterns: string[] = [
-	'<div(>|)(?:.)+?>',
-	'<span(>|)(?:.)+?>',
+	'<div(?:\\s*|\\s+.+)>',
+	'<span(?:\\s*|\\s+.+)>',
 	// "id=\"(?:.)+?\"",
 	'<a (?:.)+?>(?:(?:\\s|\\S)+?(?=</a>))</a>',
-	'<img (?:.)+?>',
-	'<input (?:.)+?>',
-	'<head (?:.|)+?>(?:(?:\\s|\\S|)+?(?=</head>))</head>',
-	'<html(>|)(?:.)+?>',
-	'tabindex="(?:.)+?"',
-	'<(?:i|)frame (?:.|)+?>',
+	'<img(?:\\s*/?|\\s+.+)>',
+	'<input(?:\\s*/?|\\s+.+)>',
+	'<head(?:\\s*|\\s+.+)>(?:(?:\\s|\\S|)+?(?=</head>))</head>',
+	'<html(?:\\s*/?|\\s+.+)>',
+	'tabindex=".*"',
+	'<i?frame(?:\\s*|\\s+.+)>',
 ];
-export const pattern: RegExp = new RegExp(patterns.join('|'), 'ig');
+export const pattern: RegExp = new RegExp(patterns.join('|'), 'igm');
 
 const nonDescriptiveAlts: string[] = [
 	'alt="image"',

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -85,9 +85,42 @@ async function validateTextDocument(textDocument: server.TextDocument): Promise<
 	let m: RegExpExecArray | null;
 	let diagnostics: server.Diagnostic[] = [];
 
+	async function _diagnostics(regEx: RegExpExecArray, diagnosticsMessage: string, severityNumber: number) {
+		let severity: server.DiagnosticSeverity;
+
+		switch (severityNumber) {
+			case 1:
+				severity = server.DiagnosticSeverity.Error;
+				break;
+			case 2:
+				severity = server.DiagnosticSeverity.Warning;
+				break;
+			case 3:
+				severity = server.DiagnosticSeverity.Information;
+				break;
+			case 4:
+				severity = server.DiagnosticSeverity.Hint;
+				break;
+		}
+
+		let diagnostic: server.Diagnostic = {
+			severity,
+			message: diagnosticsMessage,
+			range: {
+				start: textDocument.positionAt(regEx.index),
+				end: textDocument.positionAt(regEx.index + regEx[0].length),
+			},
+			code: 0,
+			source: 'web accessibility',
+		};
+
+		diagnostics.push(diagnostic);
+	}
+
 	while ((m = pattern.pattern.exec(text)) && problems < settings.maxNumberOfProblems) {
 		if (m != null) {
-			let el = m[0].slice(0, 5);
+			const el = m[0].slice(0, 5);
+
 			switch (true) {
 				// ID
 				// case (/id="/i.test(el)):
@@ -188,37 +221,6 @@ async function validateTextDocument(textDocument: server.TextDocument): Promise<
 		}
 	}
 
-	async function _diagnostics(regEx: RegExpExecArray, diagnosticsMessage: string, severityNumber: number) {
-		let severity: server.DiagnosticSeverity;
-
-		switch (severityNumber) {
-			case 1:
-				severity = server.DiagnosticSeverity.Error;
-				break;
-			case 2:
-				severity = server.DiagnosticSeverity.Warning;
-				break;
-			case 3:
-				severity = server.DiagnosticSeverity.Information;
-				break;
-			case 4:
-				severity = server.DiagnosticSeverity.Hint;
-				break;
-		}
-
-		let diagnostic: server.Diagnostic = {
-			severity,
-			message: diagnosticsMessage,
-			range: {
-				start: textDocument.positionAt(regEx.index),
-				end: textDocument.positionAt(regEx.index + regEx[0].length),
-			},
-			code: 0,
-			source: 'web accessibility',
-		};
-
-		diagnostics.push(diagnostic);
-	}
 	connection.sendDiagnostics({ uri: textDocument.uri, diagnostics });
 }
 


### PR DESCRIPTION
Hello,
I had a problem with HTML tag pattern:
- it matches with typescript generic interfaces
- it matches all tags that start with html 

```vue
<template>
<div>
  <html5-custom-tag /> <!-- Provide a language [lang=""] -->
</div>
</template>
<script lang="ts" setup>
// ...
const myTag: Ref<HTMLDivElement | null>(null); // Provide a language [lang=""]
// ...
</script>
```

I modified some regexes, I don't know if it was more optimized before, but I find my version more "simple". 🙃